### PR TITLE
Correct link to license file

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The instructions for tracking flights using Swift-based iOS app are [here](https
 
 # License
 
-[Apache 2.0](LICENSE.md)
+[Apache 2.0](LICENSE)


### PR DESCRIPTION
I renamed the license file (to drop the `.md`) in a recent commit, and broke
this link.